### PR TITLE
Enabling snpahoy to parse BED-files with more than three columns

### DIFF
--- a/src/snpahoy/parsers.py
+++ b/src/snpahoy/parsers.py
@@ -11,7 +11,7 @@ from snpahoy.core import Genotyper
 def parse_bed_file(stream: Iterable[str]) -> List[Tuple[str, int]]:
     result: List[Tuple[str, int]] = []
     for line in stream:
-        chromosome, start, stop = line.split('\t')
+        chromosome, start, stop, *_ = line.split('\t')
         for position in range(int(start), int(stop)):
             result.append((chromosome, position))
     return result


### PR DESCRIPTION
The BED-file-format allows for more than three columns. With this small fix, snpahoy will also be able to parse such BED-files.
